### PR TITLE
remove 年 from getJpYear return value

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ export const getJpYear = (date: Date): string => {
     result = Intl.DateTimeFormat('ja-JP-u-ca-japanese', {
       year: '2-digit',
       era: 'long'
-    }).format(date).slice(0, 4)
+    }).format(date).slice(0, -1)
   } catch {
     result = '該当なし'
   }


### PR DESCRIPTION
## what i do 

slice only last char.

year options '2-digit' does not return zero-padding value.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#parameters


close #1 